### PR TITLE
Avoiding issue during rebuilt and update deprecated elements

### DIFF
--- a/example/universal_widget_example/lib/main.dart
+++ b/example/universal_widget_example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:universal_widget/universal_widget.dart';
 

--- a/lib/tweener.dart
+++ b/lib/tweener.dart
@@ -1,5 +1,7 @@
 library tweener;
 
+import 'dart:async';
+
 import 'package:flutter/animation.dart';
 import 'dart:math' as math;
 import 'package:flutter/material.dart';

--- a/lib/universal_widget.dart
+++ b/lib/universal_widget.dart
@@ -403,7 +403,7 @@ class UniversalWidget extends StatefulWidget {
   
   /// The state from the closest instance of this class that encloses the given context.
   static _UniversalWidgetState of(BuildContext context){
-    return context.ancestorStateOfType(TypeMatcher<_UniversalWidgetState>());
+    return context.findAncestorStateOfType<_UniversalWidgetState>();
   }
 
   @override
@@ -483,7 +483,7 @@ class _UniversalWidgetState extends State<UniversalWidget> {
       UniversalWidget.add(widget);
     }
 
-    _parentRenderType = context.ancestorRenderObjectOfType(TypeMatcher<RenderObject>()).runtimeType.toString();
+    _parentRenderType = context.findAncestorRenderObjectOfType<RenderObject>().runtimeType.toString();
     _isBuiltFirstTime = true;
 
     if(widget.onWidgetUpdated != null){
@@ -497,7 +497,7 @@ class _UniversalWidgetState extends State<UniversalWidget> {
 
     _isBuiltFirstTime = true;
 
-    _parentRenderType = context.ancestorRenderObjectOfType(TypeMatcher<RenderObject>()).runtimeType.toString();
+    _parentRenderType = context.findAncestorRenderObjectOfType<RenderObject>().runtimeType.toString();
 
     _controller = widget._controller ?? UniversalWidgetController();
     
@@ -1108,7 +1108,7 @@ class UniversalBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context){
-    _UniversalWidgetState parentState = context.ancestorStateOfType(TypeMatcher<_UniversalWidgetState>());
+    _UniversalWidgetState parentState = context.findAncestorStateOfType<_UniversalWidgetState>();
     UniversalChannel channel = parentState.widget.channel;
     return builder(channel, context);
   }

--- a/lib/universal_widget.dart
+++ b/lib/universal_widget.dart
@@ -550,7 +550,11 @@ class _UniversalWidgetState extends State<UniversalWidget> {
 
   _widgetListener(){
     // rebuild the widget:
-    if(mounted) setState((){});
+    if(mounted){
+      WidgetsBinding.instance.addPostFrameCallback((duration){
+        setState((){});
+      });
+    } 
 
     _oldController.copyFrom(_controller);
   }


### PR DESCRIPTION
It some cases when the UniversalWidget try to rebuild during build time raise a error. I added an addPostFrame Callback:

Stacktrace below

I/flutter (14324): The following assertion was thrown while dispatching notifications for UniversalWidgetController:
I/flutter (14324): setState() or markNeedsBuild() called during build.
I/flutter (14324): This UniversalWidget widget cannot be marked as needing to build because the framework is already in
I/flutter (14324): the process of building widgets.  A widget can be marked as needing to be built during the build
I/flutter (14324): phase only if one of its ancestors is currently building. This exception is allowed because the
I/flutter (14324): framework builds parent widgets before children, which means a dirty descendant will always be
I/flutter (14324): built. Otherwise, the framework might not visit this widget during this build phase.
I/flutter (14324): The widget on which setState() or markNeedsBuild() was called was:
I/flutter (14324):   UniversalWidget